### PR TITLE
Update cypress, remove key nodeVersion in cypress.json

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,7 +4,6 @@
     "username": "admin",
     "password": "admin"
   },
-  "nodeVersion": "system",
   "viewportWidth": 1280,
   "viewportHight": 1000,
   "defaultCommandTimeout": 15000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^4.8.2",
         "axios": "^0.21.1",
         "cheerio": "^1.0.0-rc.3",
-        "cypress": "^9.3.1",
+        "cypress": "^9.5.0",
         "cypress-wait-until": "^1.7.1",
         "eslint": "^7.9.0",
         "eslint-config-prettier": "^6.11.0",
@@ -1185,9 +1185,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.3.1.tgz",
-      "integrity": "sha512-BODdPesxX6bkVUnH8BVsV8I/jn57zQtO1FEOUTiuG2us3kslW7g0tcuwiny7CKCmJUZz8S/D587ppC+s58a+5Q==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.0.tgz",
+      "integrity": "sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1228,10 +1228,10 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "bin": {
@@ -3432,16 +3432,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4106,22 +4096,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
     },
     "node_modules/utf7": {
       "version": "1.0.2",
@@ -5141,9 +5115,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.3.1.tgz",
-      "integrity": "sha512-BODdPesxX6bkVUnH8BVsV8I/jn57zQtO1FEOUTiuG2us3kslW7g0tcuwiny7CKCmJUZz8S/D587ppC+s58a+5Q==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.0.tgz",
+      "integrity": "sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -5183,10 +5157,10 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       }
     },
@@ -6828,12 +6802,6 @@
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7301,24 +7269,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
-        }
       }
     },
     "utf7": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "axios": "^0.21.1",
     "cheerio": "^1.0.0-rc.3",
-    "cypress": "^9.3.1",
+    "cypress": "^9.5.0",
     "cypress-wait-until": "^1.7.1",
     "eslint": "^7.9.0",
     "eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
Deprecation Warning: nodeVersion is currently set to system in the cypress.json configuration file.

As of Cypress version 9.0.0 the default behavior of nodeVersion has changed to always use the version of Node used to start cypress via the cli.

Please remove the nodeVersion configuration option from cypress.json.